### PR TITLE
fix: protect Job.contextCancel write with j.mu

### DIFF
--- a/looper.go
+++ b/looper.go
@@ -355,7 +355,14 @@ func (j *Job) start() error {
 	ctx, cancel := context.WithTimeout(context.Background(), j.Timeout)
 	defer cancel()
 
+	// Lock j.mu around the contextCancel write. Looper.Stop reads this field
+	// inside j.mu.Lock to cancel a running job mid-flight; without the lock
+	// here the read/write pair is a data race (caught by -race). Pattern
+	// matches j.startLoop's defer at line ~302 which already nils the field
+	// under the lock.
+	j.mu.Lock()
 	j.contextCancel = cancel
+	j.mu.Unlock()
 
 	err = j.run(ctx)
 	if err != nil {

--- a/looper_race_test.go
+++ b/looper_race_test.go
@@ -1,0 +1,53 @@
+package looper
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestStartStop_NoRaceOnContextCancel exercises the start → stop sequence
+// rapidly so the race detector can observe writes to j.contextCancel
+// (in (*Job).start) against reads in (*Looper).Stop. Run with -race; pre-fix
+// this test triggers a data-race report deterministically within a handful
+// of iterations.
+//
+// Background: (*Job).start sets j.contextCancel while holding no lock, but
+// (*Looper).Stop reads it inside j.mu.Lock to cancel an in-flight job. The
+// pattern shows up in any consumer that calls Looper.Stop shortly after
+// Looper.Start (test fixtures, controlled shutdowns during boot failure,
+// container OOM during startup).
+func TestStartStop_NoRaceOnContextCancel(t *testing.T) {
+	const iterations = 50
+
+	for i := 0; i < iterations; i++ {
+		// StartupTime: 1ms — default is 1s per job, which would add ~50s to
+		// the test for no benefit (we don't need staggered startup here, we
+		// need the start→stop race window).
+		l := New(&Config{StartupTime: time.Millisecond})
+
+		var runs atomic.Int64
+		if err := l.AddJob(context.Background(), &Job{
+			Name:             "test-job",
+			Active:           true,
+			WaitAfterSuccess: 10 * time.Millisecond,
+			WaitAfterError:   10 * time.Millisecond,
+			Timeout:          200 * time.Millisecond,
+			JobFn: func(ctx context.Context) error {
+				runs.Add(1)
+				return nil
+			},
+		}); err != nil {
+			t.Fatalf("iter %d: AddJob: %v", i, err)
+		}
+
+		l.Start()
+		// A tiny yield is enough to land the startLoop goroutine inside
+		// (*Job).start, where the unguarded write to j.contextCancel used
+		// to race with the Stop-side read. Without any sleep the race
+		// window is too narrow to catch reliably on fast machines.
+		time.Sleep(time.Millisecond)
+		l.Stop()
+	}
+}


### PR DESCRIPTION
## Problem

`(*Job).start` assigns `j.contextCancel` without holding `j.mu`, while `(*Looper).Stop` reads it inside `j.mu.Lock`. The two form a data race that Go's race detector flags reliably under tight `Start → Stop` sequences:

```
WARNING: DATA RACE
Write at 0x… by goroutine 166:
  looper.(*Job).start()      looper.go:358
Previous read at 0x… by goroutine 161:
  looper.(*Looper).Stop()    looper.go:277
```

The race window is microseconds, so production services with long uptime never observe it — by the time `Stop` is called, the launch goroutine has long since cleared the write. But three real-world patterns hit it deterministically under `-race`:

1. Test fixtures that exercise the `Run`/`Stop` lifecycle (this is how we found it — see [`bpn-api#989`](https://github.com/0xPolygon/bpn-api/pull/989))
2. Controlled shutdowns when a service decides it can't boot (a downstream config error triggers a fast Stop)
3. Container OOM-killed during startup before the looper's goroutines settle

## Fix

Wrap the `j.contextCancel = cancel` assignment in `j.mu.Lock()/Unlock()`. The existing `startLoop` defer at line ~302 already nils `contextCancel` under the same lock, so this is just symmetry on the write side. No behavioral change in normal operation.

## Regression test

`looper_race_test.go` adds `TestStartStop_NoRaceOnContextCancel` — 50 iterations of `New → AddJob → Start → tiny sleep → Stop`. `Config{StartupTime: time.Millisecond}` keeps the test fast (~4s) by skipping the default 1-second job-stagger delay.

Verified:
- **Pre-fix** with `go test -race`: fails within a handful of iterations with the data race report shown above.
- **Post-fix** with `go test -race`: passes in ~4s.

## Scope

One-line production change + one new test file. No public API changes. No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)